### PR TITLE
fix Intimidate pop-up messages: it works only when attacking

### DIFF
--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -439,7 +439,7 @@ keyword:
     title: "After you win a challenge in which this character is participating, he may gain 1 power."
   intimidate:
     name: Intimidate
-    title: "After you win a challenge in which this character is participating, you may choose and kneel a character, controlled by the losing opponent, with equal or lower STR than the amount of STR by which the challenge was won."
+    title: "After you win a challenge in which this character is participating as an attacker, you may choose and kneel a character, controlled by the losing opponent, with equal or lower STR than the amount of STR by which the challenge was won."
   stealth:
     name: Stealth
     title: "When you declare this character as an attacker, you may choose a character without stealth controlled by the defending opponent. That character cannot be declared as a defender for this challenge."

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -439,7 +439,7 @@ keyword:
     title: "Después de que ganes un reto en el que esté participando este Personaje, puedes ganar 1 de Poder para este Personaje."
   intimidate:
     name: Intimidación
-    title: "Después de que ganes un Reto en el que participe este Personaje, puedes elegir y arrodillar un Personaje controlado por el adversario derrotado cuya FUE sea igual o inferior a la diferencia de FUE por la que has ganado el reto."
+    title: "Después de que ganes un Reto en el que participe este Personaje como atacante, puedes elegir y arrodillar un Personaje controlado por el adversario derrotado cuya FUE sea igual o inferior a la diferencia de FUE por la que has ganado el reto."
   stealth:
     name: Sigilo
     title: "Cuando este Personaje sea declarado como atacante, puedes elegir un Personaje sin Sigilo controlado por el jugador defensor. Ese Personaje no puede ser declaro defensor para este reto."


### PR DESCRIPTION
fix applies to both english and spanish translations of the pop-up