### PR TITLE
Hide 'Alliance' agenda on index page to prevent misalignment

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -59,7 +59,7 @@ class DefaultController extends Controller
                     $minor_faction = $this->get('agenda_helper')->getMinorFaction($agenda->getCard());
                     if($minor_faction) {
                     	$factions[] = $minor_faction->getName();
-                    } else {
+                    } else if($agenda->getCard()->getCode() != '06018') { // prevent Alliance agenda to show up
                         $factions[] = $agenda->getCard()->getName();
                     }
                 }


### PR DESCRIPTION
When an Alliance deck is shown in index page, the house/agenda line it's too long and causes misalignment. Here is an example:
![screenshot-thronesdb com 2017-03-27 20-21-28](https://cloud.githubusercontent.com/assets/5708531/24371556/72def32a-132b-11e7-984b-257a50ab6ea2.png)

This quick fix solves it. If you see 3 houses you can guess it's using Alliance agenda... (by the moment...)
