### PR TITLE
Validate 5 different schemes for Rains decks

### DIFF
--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -163,8 +163,10 @@ class DeckValidationHelper
     public function validateRains (\AppBundle\Model\SlotCollectionInterface $slots, \AppBundle\Entity\Card $agenda)
     {
         $trait = $this->translator->trans('card.traits.scheme');
-        $matchingTraitPlots = $slots->getPlotDeck()->filterByTrait($trait)->countCards();
-        if($matchingTraitPlots !== 5) {
+        $matchingTraitPlots = $slots->getPlotDeck()->filterByTrait($trait);
+        $matchingTraitPlotsUniqueCount = $matchingTraitPlots->count();
+        $matchingTraitPlotsTotalCount = $matchingTraitPlots->countCards();
+        if($matchingTraitPlotsUniqueCount !== 5 || $matchingTraitPlotsTotalCount !== 5) {
             return false;
         }
         return true;

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -563,8 +563,10 @@
                 }
                 break;
             case '05045':
-                var schemes = deck.get_nb_cards(deck.get_cards(null, {type_code: 'plot', traits: new RegExp(Translator.trans('card.traits.scheme') + '\\.')}));
-                if(schemes !== 5) {
+                var schemeCards = deck.get_cards(null, {type_code: 'plot', traits: new RegExp(Translator.trans('card.traits.scheme') + '\\.')});
+                var totalSchemes = deck.get_nb_cards(schemeCards);
+                var uniqueSchemes = schemeCards.length;
+                if(totalSchemes !== 5 || uniqueSchemes !== 5) {
                     return false;
                 }
                 break;


### PR DESCRIPTION
Per the card text for Rains of Castamere, the deck must contain exactly
5 different scheme plots. The previous validation rules allowed decks
that contained 5 schemes total but allowed more than 1 copy of any
individual scheme.