### PR TITLE
include deck version in plain text export

### DIFF
--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -37,6 +37,7 @@ class ExportableDeck
         $slots = $this->getSlots();
         return [
             'name' => $this->getName(),
+            'version' => $this->getVersion(),
             'agendas' => $slots->getAgendas(),
             'faction' => $this->getFaction(),
             'draw_deck_size' => $slots->getDrawDeck()->countCards(),

--- a/src/AppBundle/Resources/views/Export/plain.txt.twig
+++ b/src/AppBundle/Resources/views/Export/plain.txt.twig
@@ -1,4 +1,4 @@
-{{ deck.name }}
+{{ deck.name }} {{ deck.version }}
 
 {{ deck.faction.name }}
 {% for agenda in deck.agendas %}


### PR DESCRIPTION
rationale: allow to easily differentiate between different versions of the same
deck imported elsewhere, e.g., Throneteki