### PR TITLE
Add validation rules for The Wars To Come agenda

### DIFF
--- a/src/AppBundle/Helper/DeckValidationHelper.php
+++ b/src/AppBundle/Helper/DeckValidationHelper.php
@@ -76,9 +76,13 @@ class DeckValidationHelper
 
         /* @var integer $expectedPlotDeckSize Expected number of plots */
         $expectedPlotDeckSize = 7;
+        $expectedMaxDoublePlot = 1;
         foreach ($slots->getAgendas() as $agenda) {
             if ($agenda->getCard()->getCode() === '05045') {
                 $expectedPlotDeckSize = 12;
+            } else if ($agenda->getCard()->getCode() === '10045') {
+                $expectedPlotDeckSize = 10;
+                $expectedMaxDoublePlot = 2;
             }
         }
         if ($plotDeckSize > $expectedPlotDeckSize) {
@@ -88,7 +92,7 @@ class DeckValidationHelper
             return 'too_few_plots';
         }
         /* @var integer $expectedPlotDeckSpread Expected number of different plots */
-        $expectedPlotDeckSpread = $expectedPlotDeckSize - 1;
+        $expectedPlotDeckSpread = $expectedPlotDeckSize - $expectedMaxDoublePlot;
         if (count($plotDeck) < $expectedPlotDeckSpread) {
             return 'too_many_different_plots';
         }

--- a/src/AppBundle/Resources/public/js/app.deck.js
+++ b/src/AppBundle/Resources/public/js/app.deck.js
@@ -465,11 +465,15 @@
     {
         var agendas = deck.get_agendas();
         var expectedPlotDeckSize = 7;
+        var expectedMaxDoublePlot = 1;
         var expectedMaxAgendaCount = 1;
         var expectedMinCardCount = 60;
         agendas.forEach(function (agenda) {
             if(agenda && agenda.code === '05045') {
                 expectedPlotDeckSize = 12;
+            } else if(agenda && agenda.code === '10045') {
+                expectedPlotDeckSize = 10;
+                expectedMaxDoublePlot = 2;
             }
         });
         // exactly 7 plots
@@ -480,7 +484,7 @@
             return 'too_few_plots';
         }
 
-        var expectedPlotDeckSpread = expectedPlotDeckSize - 1;
+        var expectedPlotDeckSpread = expectedPlotDeckSize - expectedMaxDoublePlot;
         // at least 6 different plots
         if(deck.get_plot_deck_variety() < expectedPlotDeckSpread) {
             return 'too_many_different_plots';


### PR DESCRIPTION
Allows having up to 2 double plots in the plot deck plus requires 10 plot cards total. https://thronesdb.com/card/10045

Fixes #192 