### PR TITLE
Add export in release date order

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -227,6 +227,41 @@ class BuilderController extends Controller
         return $response;
     }
 
+    public function binderexportAction($deck_id)
+    {
+        /* @var $em \Doctrine\ORM\EntityManager */
+        $em = $this->getDoctrine()->getManager();
+
+        /* @var $deck \AppBundle\Entity\Deck */
+        $deck = $em->getRepository('AppBundle:Deck')->find($deck_id);
+
+        $is_owner = $this->getUser() && $this->getUser()->getId() == $deck->getUser()->getId();
+        if (!$deck->getUser()->getIsShareDecks() && !$is_owner) {
+            return $this->render(
+                            'AppBundle:Default:error.html.twig',
+                array(
+                        'pagetitle' => "Error",
+                        'error' => 'You are not allowed to view this deck. To get access, you can ask the deck owner to enable "Share your decks" on their account.'
+                            )
+            );
+        }
+
+        $content = $this->renderView('AppBundle:Export:cycleorder.txt.twig', [
+            "deck" => $deck->getCycleOrderExport()
+        ]);
+        $content = str_replace("\n", "\r\n", $content);
+
+        $response = new Response();
+        $response->headers->set('Content-Type', 'text/plain');
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+                        ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $this->get('texts')->slugify($deck->getName()) . '.txt'
+        ));
+
+        $response->setContent($content);
+        return $response;
+    }
+
     public function cloneAction($deck_id)
     {
         /* @var $em \Doctrine\ORM\EntityManager */

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -227,7 +227,7 @@ class BuilderController extends Controller
         return $response;
     }
 
-    public function binderexportAction($deck_id)
+    public function textorderedexportAction($deck_id)
     {
         /* @var $em \Doctrine\ORM\EntityManager */
         $em = $this->getDoctrine()->getManager();

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -58,7 +58,7 @@ class ExportableDeck
             'draw_deck_size' => $slots->getDrawDeck()->countCards(),
             'plot_deck_size' => $slots->getPlotDeck()->countCards(),
             'included_packs' => $slots->getIncludedPacks(),
-            'slots_cycle_order' => $slots->getSlotsByCycle()
+            'slots_by_cycle_order' => $slots->getSlotsByCycleOrder()
         ];
     }
 }

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -46,4 +46,19 @@ class ExportableDeck
             'slots_by_type' => $slots->getSlotsByType()
         ];
     }
+
+    public function getCycleOrderExport()
+    {
+        $slots = $this->getSlots();
+        return [
+            'name' => $this->getName(),
+            'version' => $this->getVersion(),
+            'agendas' => $slots->getAgendas(),
+            'faction' => $this->getFaction(),
+            'draw_deck_size' => $slots->getDrawDeck()->countCards(),
+            'plot_deck_size' => $slots->getPlotDeck()->countCards(),
+            'included_packs' => $slots->getIncludedPacks(),
+            'slots_cycle_order' => $slots->getSlotsByCycle()
+        ];
+    }
 }

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -98,21 +98,25 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         return $slotsByType;
     }
 
-    public static function sortByCode($s1, $s2)
+    public static function sortByCycleOrder($s1, $s2)
     {
         return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
     }
 
-    public function getSlotsByCycle()
+    public function getSlotsByCycleOrder()
     {
-        //$slots_array = (array)$this->slots;
         $slots_array = [];
         foreach ($this->slots as $slot){
             $slots_array[] = $slot;
         }
-        //usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCode"));
-        //dump($slots_array);
-        return $slots_array;
+        usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder"));
+        
+        // At this point, $slots_array is also ordered by cycle
+        $slots_array_by_cicle = [];
+        foreach ($slots_array as $slot){
+            $slots_array_by_cicle[$slot->getCard()->getPack()->getCycle()->getName()][] = $slot;
+        }
+        return $slots_array_by_cicle;
     }
 
     public function getCountByType()

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -98,6 +98,23 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         return $slotsByType;
     }
 
+    public static function sortByCode($s1, $s2)
+    {
+        return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
+    }
+
+    public function getSlotsByCycle()
+    {
+        //$slots_array = (array)$this->slots;
+        $slots_array = [];
+        foreach ($this->slots as $slot){
+            $slots_array[] = $slot;
+        }
+        //usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCode"));
+        //dump($slots_array);
+        return $slots_array;
+    }
+
     public function getCountByType()
     {
         $countByType = ['character' => 0, 'location' => 0, 'attachment' => 0, 'event' => 0];

--- a/src/AppBundle/Model/SlotCollectionInterface.php
+++ b/src/AppBundle/Model/SlotCollectionInterface.php
@@ -29,7 +29,7 @@ interface SlotCollectionInterface extends \Countable, \IteratorAggregate, \Array
      * Get all slots sorted by cycle number (including plots)
      * @return array
      */
-    public function getSlotsByCycle();
+    public function getSlotsByCycleOrder();
     
     /**
      * Get all slot counts sorted by type code (excluding plots)

--- a/src/AppBundle/Model/SlotCollectionInterface.php
+++ b/src/AppBundle/Model/SlotCollectionInterface.php
@@ -23,7 +23,13 @@ interface SlotCollectionInterface extends \Countable, \IteratorAggregate, \Array
      * Get all slots sorted by type code (including plots)
      * @return array
      */
-    public function getSlotsByType();
+    public function getSlotsByType();    
+
+    /**
+     * Get all slots sorted by cycle number (including plots)
+     * @return array
+     */
+    public function getSlotsByCycle();
     
     /**
      * Get all slot counts sorted by type code (excluding plots)

--- a/src/AppBundle/Resources/config/routing/routing_deck.yml
+++ b/src/AppBundle/Resources/config/routing/routing_deck.yml
@@ -112,11 +112,11 @@ deck_export_text:
     requirements:
         deck_id: \d+
 
-deck_export_binder:
-    path: /export/binder/{deck_id}
+deck_export_text_ordered:
+    path: /export/text_ordered/{deck_id}
     methods: [GET]
     defaults:
-        _controller: AppBundle:Builder:binderexport
+        _controller: AppBundle:Builder:textorderedexport
     requirements:
         deck_id: \d+
 

--- a/src/AppBundle/Resources/config/routing/routing_deck.yml
+++ b/src/AppBundle/Resources/config/routing/routing_deck.yml
@@ -112,6 +112,14 @@ deck_export_text:
     requirements:
         deck_id: \d+
 
+deck_export_binder:
+    path: /export/binder/{deck_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Builder:binderexport
+    requirements:
+        deck_id: \d+
+
 deck_export_octgn_list:
     path: /export/octgn/list
     methods: [GET]

--- a/src/AppBundle/Resources/config/routing/routing_decklist.yml
+++ b/src/AppBundle/Resources/config/routing/routing_decklist.yml
@@ -7,6 +7,14 @@ decklist_export_octgn:
     requirements:
         decklist_id: \d+
 
+#decklist_export_binder:
+#    path: /export/octgn/{decklist_id}
+#    methods: [GET]
+#    defaults:
+#        _controller: AppBundle:Social:octgnexport
+#    requirements:
+#       decklist_id: \d+
+
 decklist_export_text:
     path: /export/text/{decklist_id}
     methods: [GET]

--- a/src/AppBundle/Resources/config/routing/routing_decklist.yml
+++ b/src/AppBundle/Resources/config/routing/routing_decklist.yml
@@ -7,14 +7,6 @@ decklist_export_octgn:
     requirements:
         decklist_id: \d+
 
-#decklist_export_binder:
-#    path: /export/octgn/{decklist_id}
-#    methods: [GET]
-#    defaults:
-#        _controller: AppBundle:Social:octgnexport
-#    requirements:
-#       decklist_id: \d+
-
 decklist_export_text:
     path: /export/text/{decklist_id}
     methods: [GET]

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -133,6 +133,7 @@ decks:
     download:
       text: Text file
       octgn: Octgn file
+      binderordered: Binder Ordered List file
   modals:
     card:
       go: Go to card page

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -132,8 +132,8 @@ decks:
     labelswitch: Click to switch to this tag. Shift-click to toggle this tag.
     download:
       text: Text file
+      text_cycleorder: Text file (ordered by release date)
       octgn: Octgn file
-      binderordered: Binder Ordered List file
   modals:
     card:
       go: Go to card page

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -132,6 +132,7 @@ decks:
     labelswitch: Click para cambiar a esta etiqueta. Mayús+Click para alternar esta etiqueta.
     download:
       text: Fichero de texto
+      text_cycleorder: Fichero de texto (ordenado por fecha de lanzamiento)
       octgn: Fichero OCTGN
   modals:
     card:

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -55,6 +55,7 @@
 						<ul class="dropdown-menu" role="menu">
 							<li><a href="{{ path('deck_export_text', {deck_id:deck_id}) }}">{{ 'decks.form.download.text' | trans }}</a></li>
 							<li><a href="{{ path('deck_export_octgn', {deck_id:deck_id}) }}">{{ 'decks.form.download.octgn' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_binder', {deck_id:deck_id}) }}">{{ 'decks.form.download.binderordered' | trans }}</a></li>
 						</ul>
 					</div>
 				</div>

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -54,8 +54,8 @@
 						</button>
 						<ul class="dropdown-menu" role="menu">
 							<li><a href="{{ path('deck_export_text', {deck_id:deck_id}) }}">{{ 'decks.form.download.text' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_text_ordered', {deck_id:deck_id}) }}">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
 							<li><a href="{{ path('deck_export_octgn', {deck_id:deck_id}) }}">{{ 'decks.form.download.octgn' | trans }}</a></li>
-							<li><a href="{{ path('deck_export_binder', {deck_id:deck_id}) }}">{{ 'decks.form.download.binderordered' | trans }}</a></li>
 						</ul>
 					</div>
 				</div>

--- a/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
@@ -13,6 +13,7 @@
 	</button>
 	<ul class="dropdown-menu" role="menu">
 		<li><a href="#" id="btn-download-text">{{ 'decks.form.download.text' | trans }}</a></li>
+		<li><a href="#" id="btn-download-text-cycle-ordered">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
 		<li><a href="#" id="btn-download-octgn">{{ 'decks.form.download.octgn' | trans }}</a></li>
 	</ul>
 </div>

--- a/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
+++ b/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
@@ -5,7 +5,6 @@
 {{ agenda.card.name }}
 {% endfor %}
 
-
 {% set first_pack = deck.included_packs|first %}
 {% set last_pack = deck.included_packs|last %}
 Packs: {% if deck.included_packs|length > 1 %}
@@ -14,45 +13,13 @@ From {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){
 {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){% endif %}
 {% endif %}
 
-{% set slots = deck.slots_cycle_order %}
+{% set slotsByCycle = deck.slots_by_cycle_order %}
+{% for cycle, slots in slotsByCycle  %}
+
+---- {{ cycle }} ----
 {% for slot in slots %}
-{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+#{{ "%03d" | format(slot.card.position) }} {{ slot.quantity }}x {{ slot.card.name }}
+{% endfor %}
 {% endfor %}
 
-{#
-	{% set plots = deck.slots_by_type.plot %}
-	Plot{% if plots|length > 1 %}s{% endif %}
-
-	{% for slot in plots %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set characters = deck.slots_by_type.character %}
-	Character{% if characters|length > 1 %}s{% endif %}
-
-	{% for slot in characters %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set locations = deck.slots_by_type.location %}
-	Location{% if locations|length > 1 %}s{% endif %}
-
-	{% for slot in locations %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set attachments = deck.slots_by_type.attachment %}
-	Attachment{% if attachments|length > 1 %}s{% endif %}
-
-	{% for slot in attachments %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set events = deck.slots_by_type.event %}
-	Event{% if events|length > 1 %}s{% endif %}
-
-	{% for slot in events %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-#}
 {{ footer|default('') }}

--- a/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
+++ b/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
@@ -1,0 +1,58 @@
+{{ deck.name }} {{ deck.version }}
+
+{{ deck.faction.name }}
+{% for agenda in deck.agendas %}
+{{ agenda.card.name }}
+{% endfor %}
+
+
+{% set first_pack = deck.included_packs|first %}
+{% set last_pack = deck.included_packs|last %}
+Packs: {% if deck.included_packs|length > 1 %}
+From {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){% endif %} to {{ last_pack.pack.name }}{% if last_pack.nb > 1 %} ({{ last_pack.nb }}){% endif %}
+{% else %}
+{{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){% endif %}
+{% endif %}
+
+{% set slots = deck.slots_cycle_order %}
+{% for slot in slots %}
+{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+{% endfor %}
+
+{#
+	{% set plots = deck.slots_by_type.plot %}
+	Plot{% if plots|length > 1 %}s{% endif %}
+
+	{% for slot in plots %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set characters = deck.slots_by_type.character %}
+	Character{% if characters|length > 1 %}s{% endif %}
+
+	{% for slot in characters %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set locations = deck.slots_by_type.location %}
+	Location{% if locations|length > 1 %}s{% endif %}
+
+	{% for slot in locations %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set attachments = deck.slots_by_type.attachment %}
+	Attachment{% if attachments|length > 1 %}s{% endif %}
+
+	{% for slot in attachments %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set events = deck.slots_by_type.event %}
+	Event{% if events|length > 1 %}s{% endif %}
+
+	{% for slot in events %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+#}
+{{ footer|default('') }}

--- a/src/AppBundle/Services/DeckImportService.php
+++ b/src/AppBundle/Services/DeckImportService.php
@@ -33,7 +33,7 @@ class DeckImportService
 
         foreach ($lines as $line) {
             $matches = [];
-            if (preg_match('/^\s*(\d)x?([\pLl\pLu\pN\-\.\'\!\: ]+)/u', $line, $matches)) {
+            if (preg_match('/^\s*(\d)x?([\pLl\pLu\pN\-\.\'\!\: \"]+)/u', $line, $matches)) {
                 $quantity = intval($matches[1]);
                 $name = trim($matches[2]);
             } elseif (preg_match('/^([^\(]+).*x(\d)/', $line, $matches)) {


### PR DESCRIPTION
Noticing that the website didn't allow to export in a comfortable way for people keeping cards in binders in release order, I decided to write this functionality. It will add the relative menu in the card export.

It is the second pull request I make on a project where git was not just a backup tool, and it is the first time I work with this framework, so I hope this pull won't break anything.

Also, I hope I followed the unwritten laws for pull requests. If this was not the case, let me know.