### PR TITLE
Order list export

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -227,6 +227,41 @@ class BuilderController extends Controller
         return $response;
     }
 
+    public function binderexportAction($deck_id)
+    {
+        /* @var $em \Doctrine\ORM\EntityManager */
+        $em = $this->getDoctrine()->getManager();
+
+        /* @var $deck \AppBundle\Entity\Deck */
+        $deck = $em->getRepository('AppBundle:Deck')->find($deck_id);
+
+        $is_owner = $this->getUser() && $this->getUser()->getId() == $deck->getUser()->getId();
+        if (!$deck->getUser()->getIsShareDecks() && !$is_owner) {
+            return $this->render(
+                            'AppBundle:Default:error.html.twig',
+                array(
+                        'pagetitle' => "Error",
+                        'error' => 'You are not allowed to view this deck. To get access, you can ask the deck owner to enable "Share your decks" on their account.'
+                            )
+            );
+        }
+
+        $content = $this->renderView('AppBundle:Export:cycleorder.txt.twig', [
+            "deck" => $deck->getCycleOrderExport()
+        ]);
+        $content = str_replace("\n", "\r\n", $content);
+
+        $response = new Response();
+        $response->headers->set('Content-Type', 'text/plain');
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+                        ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $this->get('texts')->slugify($deck->getName()) . '.txt'
+        ));
+
+        $response->setContent($content);
+        return $response;
+    }
+
     public function cloneAction($deck_id)
     {
         /* @var $em \Doctrine\ORM\EntityManager */

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -227,7 +227,7 @@ class BuilderController extends Controller
         return $response;
     }
 
-    public function textorderedexportAction($deck_id)
+    public function textorderedexportAction($deck_id, $deluxeAfter)
     {
         /* @var $em \Doctrine\ORM\EntityManager */
         $em = $this->getDoctrine()->getManager();
@@ -245,9 +245,8 @@ class BuilderController extends Controller
                             )
             );
         }
-
         $content = $this->renderView('AppBundle:Export:cycleorder.txt.twig', [
-            "deck" => $deck->getCycleOrderExport()
+            "deck" => $deck->getCycleOrderExport($deluxeAfter)
         ]);
         $content = str_replace("\n", "\r\n", $content);
 

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -227,7 +227,7 @@ class BuilderController extends Controller
         return $response;
     }
 
-    public function binderexportAction($deck_id)
+    public function textorderedexportAction($deck_id)
     {
         /* @var $em \Doctrine\ORM\EntityManager */
         $em = $this->getDoctrine()->getManager();

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -837,9 +837,46 @@ class SocialController extends Controller
     }
 
     /*
-     * returns a octgn file with the content of a decklist
+     * returns a text file ordered by release cycle release date
      */
 
+
+    public function textorderedexportAction($decklist_id, $deluxeAfter, Request $request)
+    {
+        $response = new Response();
+        $response->setPublic();
+        $response->setMaxAge($this->container->getParameter('cache_expiration'));
+
+        /* @var $em \Doctrine\ORM\EntityManager */
+        $em = $this->getDoctrine()->getManager();
+
+        /* @var $decklist \AppBundle\Entity\Decklist */
+        $decklist = $em->getRepository('AppBundle:Decklist')->find($decklist_id);
+        if (!$decklist) {
+            throw new NotFoundHttpException("Unable to find decklist.");
+        }
+
+        $content = $this->renderView('AppBundle:Export:cycleorder.txt.twig', [
+            "deck" => $decklist->getCycleOrderExport($deluxeAfter)
+        ]);
+        $content = str_replace("\n", "\r\n", $content);
+
+        $response = new Response();
+
+        $response->headers->set('Content-Type', 'text/plain');
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+                        ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $decklist->getNameCanonical() . '.txt'
+        ));
+
+        $response->setContent($content);
+        return $response;
+    }
+
+    /*
+     * returns a octgn file with the content of a decklist
+     */
+    
     public function octgnexportAction($decklist_id, Request $request)
     {
         $response = new Response();

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -58,7 +58,7 @@ class ExportableDeck
             'draw_deck_size' => $slots->getDrawDeck()->countCards(),
             'plot_deck_size' => $slots->getPlotDeck()->countCards(),
             'included_packs' => $slots->getIncludedPacks(),
-            'slots_cycle_order' => $slots->getSlotsByCycle()
+            'slots_by_cycle_order' => $slots->getSlotsByCycleOrder()
         ];
     }
 }

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -46,4 +46,19 @@ class ExportableDeck
             'slots_by_type' => $slots->getSlotsByType()
         ];
     }
+
+    public function getCycleOrderExport()
+    {
+        $slots = $this->getSlots();
+        return [
+            'name' => $this->getName(),
+            'version' => $this->getVersion(),
+            'agendas' => $slots->getAgendas(),
+            'faction' => $this->getFaction(),
+            'draw_deck_size' => $slots->getDrawDeck()->countCards(),
+            'plot_deck_size' => $slots->getPlotDeck()->countCards(),
+            'included_packs' => $slots->getIncludedPacks(),
+            'slots_cycle_order' => $slots->getSlotsByCycle()
+        ];
+    }
 }

--- a/src/AppBundle/Model/ExportableDeck.php
+++ b/src/AppBundle/Model/ExportableDeck.php
@@ -47,7 +47,7 @@ class ExportableDeck
         ];
     }
 
-    public function getCycleOrderExport()
+    public function getCycleOrderExport($deluxeAfter)
     {
         $slots = $this->getSlots();
         return [
@@ -58,7 +58,7 @@ class ExportableDeck
             'draw_deck_size' => $slots->getDrawDeck()->countCards(),
             'plot_deck_size' => $slots->getPlotDeck()->countCards(),
             'included_packs' => $slots->getIncludedPacks(),
-            'slots_by_cycle_order' => $slots->getSlotsByCycleOrder()
+            'slots_by_cycle_order' => $slots->getSlotsByCycleOrder($deluxeAfter)
         ];
     }
 }

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -103,7 +103,7 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
     }
 
-    public static function sortByCycleOrder_deluxeAfter($s1, $s2)
+    public static function sortByCycleOrderDeluxeAfter($s1, $s2)
     {
         // Compare cycle first. Cycle size should be enough for the moment. Core set will be first anyway.
 
@@ -133,7 +133,7 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         if (!$deluxeAfter)
             usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder"));
         else
-            usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder_deluxeAfter"));
+            usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrderDeluxeAfter"));
 
         // At this point, $slots_array is also ordered by cycle
         $slots_array_by_cicle = [];

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -98,21 +98,25 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         return $slotsByType;
     }
 
-    public static function sortByCode($s1, $s2)
+    public static function sortByCycleOrder($s1, $s2)
     {
         return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
     }
 
-    public function getSlotsByCycle()
+    public function getSlotsByCycleOrder()
     {
-        //$slots_array = (array)$this->slots;
         $slots_array = [];
         foreach ($this->slots as $slot){
             $slots_array[] = $slot;
         }
-        //usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCode"));
-        //dump($slots_array);
-        return $slots_array;
+        usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder"));
+        
+        // At this point, $slots_array is also ordered by cycle
+        $slots_array_by_cicle = [];
+        foreach ($slots_array as $slot){
+            $slots_array_by_cicle[$slot->getCard()->getPack()->getCycle()->getName()][] = $slot;
+        }
+        return $slots_array_by_cicle;
     }
 
     public function getCountByType()

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -98,6 +98,23 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         return $slotsByType;
     }
 
+    public static function sortByCode($s1, $s2)
+    {
+        return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
+    }
+
+    public function getSlotsByCycle()
+    {
+        //$slots_array = (array)$this->slots;
+        $slots_array = [];
+        foreach ($this->slots as $slot){
+            $slots_array[] = $slot;
+        }
+        //usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCode"));
+        //dump($slots_array);
+        return $slots_array;
+    }
+
     public function getCountByType()
     {
         $countByType = ['character' => 0, 'location' => 0, 'attachment' => 0, 'event' => 0];

--- a/src/AppBundle/Model/SlotCollectionDecorator.php
+++ b/src/AppBundle/Model/SlotCollectionDecorator.php
@@ -103,14 +103,38 @@ class SlotCollectionDecorator implements \AppBundle\Model\SlotCollectionInterfac
         return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
     }
 
-    public function getSlotsByCycleOrder()
+    public static function sortByCycleOrder_deluxeAfter($s1, $s2)
+    {
+        // Compare cycle first. Cycle size should be enough for the moment. Core set will be first anyway.
+
+        // If at least one is a core set slot, then ordering by code will be fine
+        $comparingCore = $s1->getCard()->getPack()->getCycle()->getPosition() == 1 || $s2->getCard()->getPack()->getCycle()->getPosition() == 1;
+
+        // If the packs have same size (both non-deluxe, or both deluxe), then ordering by code will be fine
+        $sameSize = $s1->getCard()->getPack()->getCycle()->getSize() == $s2->getCard()->getPack()->getCycle()->getSize();
+
+
+        if ($comparingCore || $sameSize)
+            // Normal ordering
+            return intval($s1->getCard()->getCode()) - intval($s2->getCard()->getCode());
+        else
+            // Cycle with size 6 (non-deluxe) should be first
+            return intval($s2->getCard()->getPack()->getCycle()->getSize()) - intval($s1->getCard()->getPack()->getCycle()->getSize());
+    }
+
+
+    public function getSlotsByCycleOrder($deluxeAfter)
     {
         $slots_array = [];
         foreach ($this->slots as $slot){
             $slots_array[] = $slot;
         }
-        usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder"));
-        
+
+        if (!$deluxeAfter)
+            usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder"));
+        else
+            usort($slots_array, array("AppBundle\Model\SlotCollectionDecorator", "sortByCycleOrder_deluxeAfter"));
+
         // At this point, $slots_array is also ordered by cycle
         $slots_array_by_cicle = [];
         foreach ($slots_array as $slot){

--- a/src/AppBundle/Model/SlotCollectionInterface.php
+++ b/src/AppBundle/Model/SlotCollectionInterface.php
@@ -29,7 +29,7 @@ interface SlotCollectionInterface extends \Countable, \IteratorAggregate, \Array
      * Get all slots sorted by cycle number (including plots)
      * @return array
      */
-    public function getSlotsByCycleOrder();
+    public function getSlotsByCycleOrder($deluxeAfter);
     
     /**
      * Get all slot counts sorted by type code (excluding plots)

--- a/src/AppBundle/Model/SlotCollectionInterface.php
+++ b/src/AppBundle/Model/SlotCollectionInterface.php
@@ -29,7 +29,7 @@ interface SlotCollectionInterface extends \Countable, \IteratorAggregate, \Array
      * Get all slots sorted by cycle number (including plots)
      * @return array
      */
-    public function getSlotsByCycle();
+    public function getSlotsByCycleOrder();
     
     /**
      * Get all slot counts sorted by type code (excluding plots)

--- a/src/AppBundle/Model/SlotCollectionInterface.php
+++ b/src/AppBundle/Model/SlotCollectionInterface.php
@@ -23,7 +23,13 @@ interface SlotCollectionInterface extends \Countable, \IteratorAggregate, \Array
      * Get all slots sorted by type code (including plots)
      * @return array
      */
-    public function getSlotsByType();
+    public function getSlotsByType();    
+
+    /**
+     * Get all slots sorted by cycle number (including plots)
+     * @return array
+     */
+    public function getSlotsByCycle();
     
     /**
      * Get all slot counts sorted by type code (excluding plots)

--- a/src/AppBundle/Resources/config/routing/routing_deck.yml
+++ b/src/AppBundle/Resources/config/routing/routing_deck.yml
@@ -112,11 +112,11 @@ deck_export_text:
     requirements:
         deck_id: \d+
 
-deck_export_binder:
-    path: /export/binder/{deck_id}
+deck_export_text_ordered:
+    path: /export/text_ordered/{deck_id}
     methods: [GET]
     defaults:
-        _controller: AppBundle:Builder:binderexport
+        _controller: AppBundle:Builder:textorderedexport
     requirements:
         deck_id: \d+
 

--- a/src/AppBundle/Resources/config/routing/routing_deck.yml
+++ b/src/AppBundle/Resources/config/routing/routing_deck.yml
@@ -112,6 +112,14 @@ deck_export_text:
     requirements:
         deck_id: \d+
 
+deck_export_binder:
+    path: /export/binder/{deck_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Builder:binderexport
+    requirements:
+        deck_id: \d+
+
 deck_export_octgn_list:
     path: /export/octgn/list
     methods: [GET]

--- a/src/AppBundle/Resources/config/routing/routing_deck.yml
+++ b/src/AppBundle/Resources/config/routing/routing_deck.yml
@@ -112,11 +112,21 @@ deck_export_text:
     requirements:
         deck_id: \d+
 
-deck_export_text_ordered:
-    path: /export/text_ordered/{deck_id}
+deck_export_text_ordered_deluxe_before:
+    path: /export/text_ordered_db/{deck_id}
     methods: [GET]
     defaults:
         _controller: AppBundle:Builder:textorderedexport
+        deluxeAfter: false
+    requirements:
+        deck_id: \d+
+
+deck_export_text_ordered_deluxe_after:
+    path: /export/text_ordered_da/{deck_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Builder:textorderedexport
+        deluxeAfter: true
     requirements:
         deck_id: \d+
 

--- a/src/AppBundle/Resources/config/routing/routing_decklist.yml
+++ b/src/AppBundle/Resources/config/routing/routing_decklist.yml
@@ -7,6 +7,14 @@ decklist_export_octgn:
     requirements:
         decklist_id: \d+
 
+#decklist_export_binder:
+#    path: /export/octgn/{decklist_id}
+#    methods: [GET]
+#    defaults:
+#        _controller: AppBundle:Social:octgnexport
+#    requirements:
+#       decklist_id: \d+
+
 decklist_export_text:
     path: /export/text/{decklist_id}
     methods: [GET]

--- a/src/AppBundle/Resources/config/routing/routing_decklist.yml
+++ b/src/AppBundle/Resources/config/routing/routing_decklist.yml
@@ -15,6 +15,24 @@ decklist_export_text:
     requirements:
         decklist_id: \d+
 
+decklist_export_text_ordered_deluxe_before:
+    path: /export/text_ordered_db/{decklist_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Social:textorderedexport
+        deluxeAfter: false
+    requirements:
+        decklist_id: \d+
+
+decklist_export_text_ordered_deluxe_after:
+    path: /export/text_ordered_da/{decklist_id}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Social:textorderedexport
+        deluxeAfter: true
+    requirements:
+        decklist_id: \d+
+
 decklist_detail:
     path: /view/{decklist_id}/{decklist_name}
     methods: [GET]

--- a/src/AppBundle/Resources/config/routing/routing_decklist.yml
+++ b/src/AppBundle/Resources/config/routing/routing_decklist.yml
@@ -7,14 +7,6 @@ decklist_export_octgn:
     requirements:
         decklist_id: \d+
 
-#decklist_export_binder:
-#    path: /export/octgn/{decklist_id}
-#    methods: [GET]
-#    defaults:
-#        _controller: AppBundle:Social:octgnexport
-#    requirements:
-#       decklist_id: \d+
-
 decklist_export_text:
     path: /export/text/{decklist_id}
     methods: [GET]

--- a/src/AppBundle/Resources/public/js/ui.decklist.js
+++ b/src/AppBundle/Resources/public/js/ui.decklist.js
@@ -34,6 +34,12 @@
             case 'btn-download-text':
                 location.href = Routing.generate('decklist_export_text', {decklist_id: app.deck.get_id()});
                 break;
+            case 'btn-download-text-cycle-ordered':
+                location.href = Routing.generate('decklist_export_text_ordered_deluxe_before', {decklist_id: app.deck.get_id()});
+                break;
+            case 'btn-download-text-cycle-ordered-deluxe-after':
+                location.href = Routing.generate('decklist_export_text_ordered_deluxe_after', {decklist_id: app.deck.get_id()});
+                break;
             case 'btn-download-octgn':
                 location.href = Routing.generate('decklist_export_octgn', {decklist_id: app.deck.get_id()});
                 break;

--- a/src/AppBundle/Resources/public/js/ui.decks.js
+++ b/src/AppBundle/Resources/public/js/ui.decks.js
@@ -184,6 +184,12 @@
             case 'btn-download-text':
                 ui.download_text_selection(ids);
                 break;
+            case 'btn-download-text-ordered':
+                ui.download_text_selection(ids);
+                break;
+            case 'btn-download-text-ordered-deluxe-after':
+                ui.download_text_selection(ids);
+                break;
             case 'btn-download-octgn':
                 ui.download_octgn_selection(ids);
                 break;

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -133,6 +133,7 @@ decks:
     download:
       text: Text file
       text_cycleorder: Text file (ordered by release date)
+      text_cycleorder_deluxe_after: Text file (ordered by release date, deluxe after)
       octgn: Octgn file
   modals:
     card:

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -133,6 +133,7 @@ decks:
     download:
       text: Text file
       octgn: Octgn file
+      binderordered: Binder Ordered List file
   modals:
     card:
       go: Go to card page

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -132,8 +132,8 @@ decks:
     labelswitch: Click to switch to this tag. Shift-click to toggle this tag.
     download:
       text: Text file
+      text_cycleorder: Text file (ordered by release date)
       octgn: Octgn file
-      binderordered: Binder Ordered List file
   modals:
     card:
       go: Go to card page

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -132,6 +132,7 @@ decks:
     labelswitch: Click para cambiar a esta etiqueta. Mayús+Click para alternar esta etiqueta.
     download:
       text: Fichero de texto
+      text_cycleorder: Fichero de texto (ordenado por fecha de lanzamiento)
       octgn: Fichero OCTGN
   modals:
     card:

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -133,6 +133,7 @@ decks:
     download:
       text: Fichero de texto
       text_cycleorder: Fichero de texto (ordenado por fecha de lanzamiento)
+      text_cycleorder_deluxe_after: Fichero de texto (ordenado por fecha de lanzamiento, deluxe al final)
       octgn: Fichero OCTGN
   modals:
     card:

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -55,6 +55,7 @@
 						<ul class="dropdown-menu" role="menu">
 							<li><a href="{{ path('deck_export_text', {deck_id:deck_id}) }}">{{ 'decks.form.download.text' | trans }}</a></li>
 							<li><a href="{{ path('deck_export_octgn', {deck_id:deck_id}) }}">{{ 'decks.form.download.octgn' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_binder', {deck_id:deck_id}) }}">{{ 'decks.form.download.binderordered' | trans }}</a></li>
 						</ul>
 					</div>
 				</div>

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -54,7 +54,8 @@
 						</button>
 						<ul class="dropdown-menu" role="menu">
 							<li><a href="{{ path('deck_export_text', {deck_id:deck_id}) }}">{{ 'decks.form.download.text' | trans }}</a></li>
-							<li><a href="{{ path('deck_export_text_ordered', {deck_id:deck_id}) }}">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_text_ordered_deluxe_before', {deck_id:deck_id}) }}">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_text_ordered_deluxe_after', {deck_id:deck_id}) }}">{{ 'decks.form.download.text_cycleorder_deluxe_after' | trans }}</a></li>
 							<li><a href="{{ path('deck_export_octgn', {deck_id:deck_id}) }}">{{ 'decks.form.download.octgn' | trans }}</a></li>
 						</ul>
 					</div>

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -54,8 +54,8 @@
 						</button>
 						<ul class="dropdown-menu" role="menu">
 							<li><a href="{{ path('deck_export_text', {deck_id:deck_id}) }}">{{ 'decks.form.download.text' | trans }}</a></li>
+							<li><a href="{{ path('deck_export_text_ordered', {deck_id:deck_id}) }}">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
 							<li><a href="{{ path('deck_export_octgn', {deck_id:deck_id}) }}">{{ 'decks.form.download.octgn' | trans }}</a></li>
-							<li><a href="{{ path('deck_export_binder', {deck_id:deck_id}) }}">{{ 'decks.form.download.binderordered' | trans }}</a></li>
 						</ul>
 					</div>
 				</div>

--- a/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
@@ -13,6 +13,7 @@
 	</button>
 	<ul class="dropdown-menu" role="menu">
 		<li><a href="#" id="btn-download-text">{{ 'decks.form.download.text' | trans }}</a></li>
+		<li><a href="#" id="btn-download-text-cycle-ordered">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
 		<li><a href="#" id="btn-download-octgn">{{ 'decks.form.download.octgn' | trans }}</a></li>
 	</ul>
 </div>

--- a/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/toolbar.html.twig
@@ -14,6 +14,7 @@
 	<ul class="dropdown-menu" role="menu">
 		<li><a href="#" id="btn-download-text">{{ 'decks.form.download.text' | trans }}</a></li>
 		<li><a href="#" id="btn-download-text-cycle-ordered">{{ 'decks.form.download.text_cycleorder' | trans }}</a></li>
+		<li><a href="#" id="btn-download-text-cycle-ordered-deluxe-after">{{ 'decks.form.download.text_cycleorder_deluxe_after' | trans }}</a></li>
 		<li><a href="#" id="btn-download-octgn">{{ 'decks.form.download.octgn' | trans }}</a></li>
 	</ul>
 </div>

--- a/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
+++ b/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
@@ -18,7 +18,7 @@ From {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){
 
 ---- {{ cycle }} ----
 {% for slot in slots %}
-#{{ "%03d" | format(slot.card.position) }} {{ slot.quantity }}x {{ slot.card.name }}
+#{{ "%03d" | format(slot.card.position) }} {{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
 {% endfor %}
 {% endfor %}
 

--- a/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
+++ b/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
@@ -5,7 +5,6 @@
 {{ agenda.card.name }}
 {% endfor %}
 
-
 {% set first_pack = deck.included_packs|first %}
 {% set last_pack = deck.included_packs|last %}
 Packs: {% if deck.included_packs|length > 1 %}
@@ -14,45 +13,13 @@ From {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){
 {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){% endif %}
 {% endif %}
 
-{% set slots = deck.slots_cycle_order %}
+{% set slotsByCycle = deck.slots_by_cycle_order %}
+{% for cycle, slots in slotsByCycle  %}
+
+---- {{ cycle }} ----
 {% for slot in slots %}
-{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+#{{ "%03d" | format(slot.card.position) }} {{ slot.quantity }}x {{ slot.card.name }}
+{% endfor %}
 {% endfor %}
 
-{#
-	{% set plots = deck.slots_by_type.plot %}
-	Plot{% if plots|length > 1 %}s{% endif %}
-
-	{% for slot in plots %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set characters = deck.slots_by_type.character %}
-	Character{% if characters|length > 1 %}s{% endif %}
-
-	{% for slot in characters %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set locations = deck.slots_by_type.location %}
-	Location{% if locations|length > 1 %}s{% endif %}
-
-	{% for slot in locations %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set attachments = deck.slots_by_type.attachment %}
-	Attachment{% if attachments|length > 1 %}s{% endif %}
-
-	{% for slot in attachments %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-
-	{% set events = deck.slots_by_type.event %}
-	Event{% if events|length > 1 %}s{% endif %}
-
-	{% for slot in events %}
-	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
-	{% endfor %}
-#}
 {{ footer|default('') }}

--- a/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
+++ b/src/AppBundle/Resources/views/Export/cycleorder.txt.twig
@@ -1,0 +1,58 @@
+{{ deck.name }} {{ deck.version }}
+
+{{ deck.faction.name }}
+{% for agenda in deck.agendas %}
+{{ agenda.card.name }}
+{% endfor %}
+
+
+{% set first_pack = deck.included_packs|first %}
+{% set last_pack = deck.included_packs|last %}
+Packs: {% if deck.included_packs|length > 1 %}
+From {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){% endif %} to {{ last_pack.pack.name }}{% if last_pack.nb > 1 %} ({{ last_pack.nb }}){% endif %}
+{% else %}
+{{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){% endif %}
+{% endif %}
+
+{% set slots = deck.slots_cycle_order %}
+{% for slot in slots %}
+{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+{% endfor %}
+
+{#
+	{% set plots = deck.slots_by_type.plot %}
+	Plot{% if plots|length > 1 %}s{% endif %}
+
+	{% for slot in plots %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set characters = deck.slots_by_type.character %}
+	Character{% if characters|length > 1 %}s{% endif %}
+
+	{% for slot in characters %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set locations = deck.slots_by_type.location %}
+	Location{% if locations|length > 1 %}s{% endif %}
+
+	{% for slot in locations %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set attachments = deck.slots_by_type.attachment %}
+	Attachment{% if attachments|length > 1 %}s{% endif %}
+
+	{% for slot in attachments %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+
+	{% set events = deck.slots_by_type.event %}
+	Event{% if events|length > 1 %}s{% endif %}
+
+	{% for slot in events %}
+	{{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
+	{% endfor %}
+#}
+{{ footer|default('') }}

--- a/src/AppBundle/Services/DeckImportService.php
+++ b/src/AppBundle/Services/DeckImportService.php
@@ -36,6 +36,9 @@ class DeckImportService
             if (preg_match('/^\s*(\d)x?([\pLl\pLu\pN\-\.\'\!\: ]+)/u', $line, $matches)) {
                 $quantity = intval($matches[1]);
                 $name = trim($matches[2]);
+            }elseif (preg_match('/^\s*#\d{3}\s(\d)x?([\pLl\pLu\pN\-\.\'\!\: ]+)/u', $line, $matches)) {
+                $quantity = intval($matches[1]);
+                $name = trim($matches[2]);
             } elseif (preg_match('/^([^\(]+).*x(\d)/', $line, $matches)) {
                 $quantity = intval($matches[2]);
                 $name = trim($matches[1]);


### PR DESCRIPTION
Noticing that the website didn't allow to export in a comfortable way for people keeping cards in binders in release order, I decided to write this functionality. It will add the relative menu in the card export.

It is the second pull request I make on a project where git was not just a backup tool, and it is the first time I work with this framework, so I hope this pull won't break anything.

Also, I hope I followed the unwritten laws for pull requests. If this was not the case, let me know.