### PR TITLE
Shadow tooltip

### DIFF
--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -465,5 +465,5 @@ keyword:
     title: "When this card enters play, move up to X gold from your gold pool to this card."
   shadow:
     name: Shadow
-    title: " A card with shadow (X) can be marshaled facedown into its controller’s shadows area for 2 gold. That card can later be played (if it is an event) or brought into play faceup (if it is a character, location, or attachment) by paying X gold."
+    title: "A card with shadow (X) can be marshaled facedown into its controller’s shadows area for 2 gold. That card can later be played (if it is an event) or brought into play faceup (if it is a character, location, or attachment) by paying X gold."
   

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -465,5 +465,5 @@ keyword:
     title: "When this card enters play, move up to X gold from your gold pool to this card."
   shadow:
     name: Shadow
-    title: "Marshal this card facedown into the shadows for 2 gold. As an action, pay 0 gold to bring it into play faceup."
+    title: " A card with shadow (X) can be marshaled facedown into its controller’s shadows area for 2 gold. That card can later be played (if it is an event) or brought into play faceup (if it is a character, location, or attachment) by paying X gold."
   

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -463,4 +463,7 @@ keyword:
   bestow:
     name: Bestow
     title: "When this card enters play, move up to X gold from your gold pool to this card."
+  shadow:
+    name: Shadow
+    title: "Marshal this card facedown into the shadows for 2 gold. As an action, pay 0 gold to bring it into play faceup."
   

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -462,6 +462,6 @@ keyword:
   bestow:
     name: Encomienda
     title: "Cuando esta carta entre en juego, traslada hasta X de Oro de tu suministro de Oro hasta esta carta."
-  shadows:
+  shadow:
     name: Sombra
     title: "Marshal this card facedown into the shadows for 2 gold. As an action, pay 0 gold to bring it into play faceup."

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -464,4 +464,4 @@ keyword:
     title: "Cuando esta carta entre en juego, traslada hasta X de Oro de tu suministro de Oro hasta esta carta."
   shadow:
     name: Sombra
-    title: "Marshal this card facedown into the shadows for 2 gold. As an action, pay 0 gold to bring it into play faceup."
+    title: "A card with shadow (X) can be marshaled facedown into its controller’s shadows area for 2 gold. That card can later be played (if it is an event) or brought into play faceup (if it is a character, location, or attachment) by paying X gold."

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -462,3 +462,6 @@ keyword:
   bestow:
     name: Encomienda
     title: "Cuando esta carta entre en juego, traslada hasta X de Oro de tu suministro de Oro hasta esta carta."
+  shadows:
+    name: Sombra
+    title: "Marshal this card facedown into the shadows for 2 gold. As an action, pay 0 gold to bring it into play faceup."

--- a/src/AppBundle/Resources/views/Default/rulesreference.en.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.en.html.twig
@@ -667,7 +667,7 @@ span.new	{ color:red }
 <ul>
 <li>  Sometimes a keyword is followed by reminder text, which is presented in italics. Reminder text is a shorthand explanation of how a keyword works, but it is not rules text and does not replace the rules for that keyword in this glossary.</li>
 <li>  Cards are considered to have a keyword or to not have that keyword. A single card that has and/or is gaining the same keyword from multiple sources functions as if it has one instance of that keyword. (Note: Instances of Ambush (X) with different values for X are considered different keywords.)</li>
-<li>  The keywords in the game are: ambush (X), insight, intimidate, limited, no attachments, pillage, renown, shadow (X), stealth, and terminal.</li>
+<li>  The keywords in the game are: ambush (X), bestow (X), insight, intimidate, limited, no attachments, pillage, renown, shadow (X), stealth, and terminal.</li>
 </ul>
 
 <p><strong>Related:</strong> <a href="#Ambush">Ambush (X)</a>, <a href="#Insight">Insight</a>, <a href="#Intimidate">Intimidate</a>, <a href="#Limited">Limited</a>, <a href="#No_Attachments">No Attachments</a>, <a href="#Pillage">Pillage</a>, <a href="#Renown">Renown</a>, <a href="#Stealth">Stealth</a>, <a href="#Terminal">Terminal</a></p>

--- a/src/AppBundle/Resources/views/Default/rulesreference.en.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.en.html.twig
@@ -667,7 +667,7 @@ span.new	{ color:red }
 <ul>
 <li>  Sometimes a keyword is followed by reminder text, which is presented in italics. Reminder text is a shorthand explanation of how a keyword works, but it is not rules text and does not replace the rules for that keyword in this glossary.</li>
 <li>  Cards are considered to have a keyword or to not have that keyword. A single card that has and/or is gaining the same keyword from multiple sources functions as if it has one instance of that keyword. (Note: Instances of Ambush (X) with different values for X are considered different keywords.)</li>
-<li>  The keywords in the game are: ambush (X), insight, intimidate, limited, no attachments, pillage, renown, stealth, and terminal.</li>
+<li>  The keywords in the game are: ambush (X), insight, intimidate, limited, no attachments, pillage, renown, shadow (X), stealth, and terminal.</li>
 </ul>
 
 <p><strong>Related:</strong> <a href="#Ambush">Ambush (X)</a>, <a href="#Insight">Insight</a>, <a href="#Intimidate">Intimidate</a>, <a href="#Limited">Limited</a>, <a href="#No_Attachments">No Attachments</a>, <a href="#Pillage">Pillage</a>, <a href="#Renown">Renown</a>, <a href="#Stealth">Stealth</a>, <a href="#Terminal">Terminal</a></p>

--- a/src/AppBundle/Services/CardsData.php
+++ b/src/AppBundle/Services/CardsData.php
@@ -62,7 +62,7 @@ class CardsData
      */
     public function addAbbrTags($text)
     {
-        static $keywords = ['renown', 'intimidate', 'stealth', 'insight', 'limited', 'pillage', 'terminal', 'ambush', 'bestow'];
+        static $keywords = ['renown', 'intimidate', 'stealth', 'insight', 'limited', 'pillage', 'terminal', 'ambush', 'bestow', 'shadow'];
 
         $locale = $this->request_stack->getCurrentRequest() ? $this->request_stack->getCurrentRequest()->getLocale() : 'en';
 


### PR DESCRIPTION
fixes #221
 
![selection_164](https://user-images.githubusercontent.com/1410427/47900327-be2e2f00-de39-11e8-8ef2-4c8ff05041ae.png)

Needs a proper Spanish translation, still. Which I couldn't find online, yet.